### PR TITLE
Git diff w/Submodule throws warning

### DIFF
--- a/src/PHPCodeCoverageVerifier/CodeCoverageVerifier.php
+++ b/src/PHPCodeCoverageVerifier/CodeCoverageVerifier.php
@@ -72,7 +72,13 @@ class CodeCoverageVerifier
 
 		foreach ($extracted_data as $filename => $line) {
 			$file_node = $clover_xml->find_file($filename);
-
+			
+			if (empty($line))
+			{
+				//No lines were actually changed. Can be ignored
+				continue;
+			}
+			
 			foreach ($line['line'] as $id => $range) {
 				$ignored = false;
 

--- a/tests/CodeCoverageVerifierTest.php
+++ b/tests/CodeCoverageVerifierTest.php
@@ -106,4 +106,13 @@ class CodeCoverageVerifierTest extends PHPUnit_Framework_TestCase
 		$expected['details']['not-covered'] = 2;
 		$this->assertEquals($expected, $coverage);
 	}
+	
+	public function testsExecuteCloverXmlWithGitSubmodule()
+	{
+		$codeCoverageVerifier = new CodeCoverageVerifier();
+		$coverage = $codeCoverageVerifier->execute_file($this->fixture('clover_xml.xml'), $this->fixture('submodule.diff'));
+
+		$expected = $codeCoverageVerifier->get_default_coverage_result();
+		$this->assertEquals($expected, $coverage);
+	}
 }

--- a/tests/fixtures/submodule.diff
+++ b/tests/fixtures/submodule.diff
@@ -1,0 +1,7 @@
+diff --git some_submodule some_submodule
+index f63f9d6..5305eac 160000
+--- some_submodule
++++ some_submodule
+@@ -1 +1 @@
+-Subproject commit f63f9d60d9a339dd6d65a5db878e59ab018e48c6
++Subproject commit 5305eacf150335ed9527839cdd15636ba8780435


### PR DESCRIPTION
Fixes a bug where a git submodule change in the git diff would cause the script to throw a warning with the following error:

```
Undefined index: line
/vendor/tomzx/php-code-coverage-verifier/src/PHPCodeCoverageVerifier/CodeCoverageVerifier.php:85
/vendor/tomzx/php-code-coverage-verifier/src/PHPCodeCoverageVerifier/CodeCoverageVerifier.php:126
/vendor/tomzx/php-code-coverage-verifier/tests/CodeCoverageVerifierTest.php:113

```

https://github.com/tomzx/php-code-coverage-verifier/issues/10
